### PR TITLE
Avoid confusion with SymLink to rootfs.squashfs

### DIFF
--- a/board/fischertechnik/TXT/post-image.sh
+++ b/board/fischertechnik/TXT/post-image.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-ln -sf rootfs.squashfs "$1/rootfs.img"
+mv -f "$1/rootfs.squashfs" "$1/rootfs.img"


### PR DESCRIPTION
The current build process creates a file rootfs.squashfs and a SymLink to this file named rootfs.img. 
rootfs.img is the file required for the TXT but due to the symlink cannot easily be copied to the FAT-formatted SD-Card.

As the rootfs.squashfs-File is (currently?) only used as link target but for no other purposes, the proposed solution is to rename rootfs.squashfs to rootfs.img, thereby making rootfs.img copyable as the other required files.