### PR TITLE
minor bugfix in WLAN App - now compatible to fw<0.9.3 again

### DIFF
--- a/board/fischertechnik/TXT/rootfs/opt/ftc/apps/system/wlan/wlan.py
+++ b/board/fischertechnik/TXT/rootfs/opt/ftc/apps/system/wlan/wlan.py
@@ -236,8 +236,10 @@ class KeyDialog(TouchDialog):
     def exec_(self):
         TouchDialog.exec_(self)
         if self.confbutpressed: return self.line.text()
-        else:                   return self.strg
-      
+        else:
+            if TouchStyle_version>1.3: return self.strg 
+            else: return self.line.text()
+          
 # background thread to monitor state of interface
 class MonitorThread(QThread):
     def __init__(self):


### PR DESCRIPTION
Keyboard was no longer compatible to fw<0.9.3, fixed