### PR TITLE
Fix missing desc or exec in manifest

### DIFF
--- a/board/fischertechnik/TXT/rootfs/var/www/applist.py
+++ b/board/fischertechnik/TXT/rootfs/var/www/applist.py
@@ -67,7 +67,10 @@ for app_dir in scan_app_dirs():
 
     # get various fields from manifest
     appname = manifest.get('app', 'name')
-    description = manifest.get('app', 'desc')
+    if manifest.has_option('app', 'desc'):
+        description = manifest.get('app', 'desc')
+    else:
+        description = "no desc"
     # the icon name is a little tricky as the web server accesses files
     # relative to its document root
     group_dir, app_dir_name = os.path.split(app_dir)
@@ -76,9 +79,11 @@ for app_dir in scan_app_dirs():
         iconname = os.path.join( "apps", group_dir_name, app_dir_name, manifest.get('app', 'icon'))
     else:
         iconname = "icon.png"
-        
-    executable = os.path.join(app_dir, manifest.get('app', 'exec'))
-    exec_relative = os.path.join(group_dir_name, app_dir_name, manifest.get('app', 'exec'))
+
+    if manifest.has_option('app', 'exec'):
+        exec_relative = os.path.join(group_dir_name, app_dir_name, manifest.get('app', 'exec'))
+    else:
+        exec_relative = ''
     is_running = current_executable == exec_relative
 
     if count == 0:


### PR DESCRIPTION
Fix
![image](https://cloud.githubusercontent.com/assets/17218193/24588845/9678a372-17d0-11e7-84f6-4d1e0d07fea4.png)
and
```
Traceback (most recent call last):
  File "/home/raphael/ftcommunity-TXT/output/target/usr/lib/python3.5/configparser.py", line 786, in get
  File "/home/raphael/ftcommunity-TXT/output/target/usr/lib/python3.5/collections/__init__.py", line 878, in __getitem__
  File "/home/raphael/ftcommunity-TXT/output/target/usr/lib/python3.5/collections/__init__.py", line 870, in __missing__
KeyError: 'desc'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/www/applist.py", line 70, in <module>
    description = manifest.get('app', 'desc')
  File "/home/raphael/ftcommunity-TXT/output/target/usr/lib/python3.5/configparser.py", line 789, in get
configparser.NoOptionError: No option 'desc' in section: 'app'
```

This can occur when the manifest looks like:
```
[app]
name: Hello World
```