### PR TITLE
Add root check to power scripts

### DIFF
--- a/board/fischertechnik/TXT/rootfs/sbin/poweroff
+++ b/board/fischertechnik/TXT/rootfs/sbin/poweroff
@@ -1,3 +1,7 @@
 #!/bin/sh
+if [ "$(whoami)" != "root" ]; then
+  echo "$0 must be run as root" >&2;
+  exit 1
+fi
 /bin/launcher-msg "Shutting down..."
 exec /bin/busybox poweroff

--- a/board/fischertechnik/TXT/rootfs/sbin/reboot
+++ b/board/fischertechnik/TXT/rootfs/sbin/reboot
@@ -1,4 +1,8 @@
 #!/bin/sh
+if [ "$(whoami)" != "root" ]; then
+  echo "$0 must be run as root" >&2;
+  exit 1
+fi
 /bin/launcher-msg "Rebooting..."
 echo +15 > /sys/class/rtc/rtc1/wakealarm
 exec /bin/busybox poweroff


### PR DESCRIPTION
Without this patch running `poweroff`, `halt` or `reboot` without root, the launcher will be blocked with the info message, but the TXT will not poweroff/reboot.

Raphael