### PR TITLE
Disallow ftc and ROBOPro access to spidev

### DIFF
--- a/board/fischertechnik/TXT/rootfs/etc/udev/rules.d/30-spidev.rules
+++ b/board/fischertechnik/TXT/rootfs/etc/udev/rules.d/30-spidev.rules
@@ -1,0 +1,1 @@
+KERNEL=="spidev*", RUN="/bin/sh -c 'chgrp -R root /dev/spidev*'"


### PR DESCRIPTION
Now ftrobopy and ROBOPro has no sound anymore. ROBOPro will just write a warning line to shell and it still works.
Next step is adding new sound support to ftrobopy.
Maybe later I will start/stop the alsa process when start/stop ROBOPro