### PR TITLE
Optional "category" for the Web-UI

### DIFF
--- a/board/fischertechnik/TXT/rootfs/var/www/appinfo.py
+++ b/board/fischertechnik/TXT/rootfs/var/www/appinfo.py
@@ -87,7 +87,7 @@ if os.path.isfile(manifestfile):
     print('<table align="center">')
     if author:
         print('<tr><td><b>Author:</b></td><td>', author, '</td></tr>')
-    if category is not None:
+    if category:
         print('<tr><td><b>Category:</b></td><td>', category, '</td></tr>')
     print('<tr><td><b>Description:</b></td><td>', description, '</td></tr>')
     print('</table>')


### PR DESCRIPTION
Acc. to the docs <https://cfw.ftcommunity.de/ftcommunity-TXT/de/programming/python/tutorial-1.html> the key "category" is optional but ``appinfo.py`` fails if no category is provided.

Assuming that the docs are right, this patch fixes the wrong assumption and adds some documentation.

* Made "category" optional
* Added docs
* Fixed some WS issues