### PR TITLE
Made TouchStyle more TX-Pi friendly

### DIFF
--- a/board/fischertechnik/TXT/rootfs/opt/ftc/TouchStyle.py
+++ b/board/fischertechnik/TXT/rootfs/opt/ftc/TouchStyle.py
@@ -12,7 +12,8 @@ from PyQt4.QtGui import *
 
 # enable special features for the Fischertechnik TXT
 # The TXT can be detected by the presence of /etc/fw-ver.txt
-TXT = os.path.isfile("/etc/fw-ver.txt")
+# Since the TX-Pi hasn't a hardware button, TXT MUST be ``False`` for the TX-Pi
+TXT = os.path.isfile("/etc/fw-ver.txt") and not os.path.isfile('/etc/tx-pi')
 # check for Fischertechnik community firmware app development settings
 DEV = os.path.isfile("/etc/ft-cfw-dev.txt")
 

--- a/docs/de/programming/python/tutorial-2.md
+++ b/docs/de/programming/python/tutorial-2.md
@@ -29,6 +29,11 @@ $ export PYTHONPATH=/opt/ftc
 $ /opt/ftc/apps/user/191fe5a6-313b-4083-af65-d1ad7fd6d281/test.py
 ```
 
+Hinweis an TX-Pi-Entwickler: Wenn das Programm mit der Fehlermeldung "cannot connect to X server" abbricht, muß folgender Befehl vor dem Ausführen des Programmes ausgeführt werden:
+```
+export DISPLAY=:0.0
+```
+
 Der Pfad ergibt sich wieder aus der UUID, wie sie in der Manifest-Datei deiner App steht.
 
 Jetzt kannst du Fehlermeldungen und Debug-Ausgaben in deiner Remote-Shell sehen.

--- a/docs/en/programming/python/tutorial-2.md
+++ b/docs/en/programming/python/tutorial-2.md
@@ -29,6 +29,11 @@ $ export PYTHONPATH=/opt/ftc
 $ /opt/ftc/apps/user/191fe5a6-313b-4083-af65-d1ad7fd6d281/test.py
 ```
 
+Note to TX-Pi users: If you get an error "cannot connect to X server", you need to run the following command in advance:
+```
+export DISPLAY=:0.0
+```
+
 Again the path is derived from the UUID in the manifest file of your app.
 
 You'll then see the error messages and debug output on the remote shell.


### PR DESCRIPTION
Due to the missing hardware button, TouchStyle throws an exception during boot. This patch ensures that the contant ``TXT`` is set to ``False`` if a TX-Pi is detected.

Further, I updated the tutorial to get around another error which may occur if someone uses the TX-Pi.

See also ftCommunity/tx-pi#35