### PR TITLE
fix pkill command

### DIFF
--- a/package/ft_bt_remote_server/0001-Add-sudoers.d-file.patch
+++ b/package/ft_bt_remote_server/0001-Add-sudoers.d-file.patch
@@ -16,8 +16,10 @@ index 0000000..69f8429
 @@ -0,0 +1,4 @@
 +## Permissions for ftc access to programs required
 +## for BT Control Set server setup
+##
+## Please note that the process name is limited to 15 characters.
 +
-+ftc     ALL = NOPASSWD: /usr/bin/ft_bt_remote_start.sh, /usr/bin/ft_bt_remote_server, /bin/pkill -SIGINT ft_bt_remote_server
++ftc     ALL = NOPASSWD: /usr/bin/ft_bt_remote_start.sh, /usr/bin/ft_bt_remote_server, /bin/pkill -SIGINT ft_bt_remote_se
 -- 
 2.18.0
 


### PR DESCRIPTION
the old pkill command would not succeed as Linux process names are automatically limited to 15 characters