### PR TITLE
enable bgscan to change to a better access point

### DIFF
--- a/board/fischertechnik/TXT/rootfs/etc/wpa_supplicant.conf
+++ b/board/fischertechnik/TXT/rootfs/etc/wpa_supplicant.conf
@@ -1,4 +1,4 @@
 ctrl_interface=/var/run/wpa_supplicant
 ap_scan=1
 update_config=1
-
+bgscan="simple:30:-60:3600"


### PR DESCRIPTION
Every 30 seconds, if less than -60dB rx quality, perform a background scan for better access points (otherwise every 3600s)