### PR TITLE
set environment variables for a ssh login

### DIFF
--- a/board/fischertechnik/TXT/rootfs/etc/profile.d/ftc.sh
+++ b/board/fischertechnik/TXT/rootfs/etc/profile.d/ftc.sh
@@ -1,0 +1,3 @@
+# ftc-specific environment variables
+export PYTHONPATH=/opt/ftc
+export DISPLAY=:0 

--- a/docs/de/programming/python/tutorial-2.md
+++ b/docs/de/programming/python/tutorial-2.md
@@ -25,7 +25,6 @@ Jetzt kannst du die aktualisierte App auf dem TXT mit dem Launcher starten.
 Wenn Apps über den Launcher (Startbildschirm) gestartet werden, werden keine Fehlermeldungen angezeigt. Dies kann während der Entwicklung ein Nachteil sein. Du kannst die Apps auch starten, wenn du über SSH (als User "ftc", kein Passwort) auf dem TXT eingeloggt bist. Verbinde dich zuerst über SSH mit dem TXT (z.B. `ssh ftc@192.168.0.12`). Du musst auf dem TXT die Verbindung erlauben. In der Remote Shell gibst du ein:
 
 ```
-$ export PYTHONPATH=/opt/ftc
 $ /opt/ftc/apps/user/191fe5a6-313b-4083-af65-d1ad7fd6d281/test.py
 ```
 

--- a/docs/en/programming/python/tutorial-2.md
+++ b/docs/en/programming/python/tutorial-2.md
@@ -25,7 +25,6 @@ You can now start your updated app on the TXT using the launcher.
 When apps are being started using the launcher no debug output and no error messages are visible. This may be a problem during development. You can launch apps when being logged in into the TXT via SSH (as user "ftc", no password). In order to start the test app log into the TXT via SSH first. Then type:
 
 ```
-$ export PYTHONPATH=/opt/ftc
 $ /opt/ftc/apps/user/191fe5a6-313b-4083-af65-d1ad7fd6d281/test.py
 ```
 


### PR DESCRIPTION
Please not that this only works for interactive sessions. Non-interactive sessions like "ssh txt command" will not have these environment variables as they bypass the busybox shell.