### PR TITLE
fix robopro issues

### DIFF
--- a/board/fischertechnik/TXT/initramfs/repartition-sd-card
+++ b/board/fischertechnik/TXT/initramfs/repartition-sd-card
@@ -74,7 +74,7 @@ chmod go-rwx /media/sdcard/data/overlay/ || fail
 mkdir -p /media/sdcard/data/home/ftc/apps || fail
 chown -R 1001:1001 /media/sdcard/data/home/ftc || fail
 mkdir -p /media/sdcard/data/home/ROBOPro/ROBOProFiles || fail
-chown -R 1000:1000 /media/sdcard/data/home/ROBOPro || fail
+chown -R 1004:1008 /media/sdcard/data/home/ROBOPro || fail
 umount /media/sdcard/data || fail
 
 progress 100 "finished"

--- a/board/fischertechnik/TXT/rootfs/etc/fstab
+++ b/board/fischertechnik/TXT/rootfs/etc/fstab
@@ -12,4 +12,4 @@ overlay			/etc			overlay	lowerdir=/media/sdcard/root/etc,upperdir=/media/sdcard/
 /dev/shm		/rom/dev/shm	bind	bind		0	0
 /tmp			/rom/tmp		bind	bind		0	0
 /sys			/rom/sys		bind	bind		0	0
-/home/ROBOPro/ROBOProFiles	/rom/opt/knobloch/ROBOProFiles	bind	bind		0	0
+/home/ROBOPro/ROBOProFiles	/rom/opt/knobloch/ROBOPro	bind	bind		0	0

--- a/board/fischertechnik/TXT/rootfs/opt/fischertechnik/run-txtcontrol
+++ b/board/fischertechnik/TXT/rootfs/opt/fischertechnik/run-txtcontrol
@@ -6,5 +6,6 @@ while [ -f /run/txtcontrol-service -o -f /run/txtcontrol-app ] ; do
     else
         DISPLAY="SDL_VIDEODRIVER=dummy"
     fi
+    chown -R ROBOPro:ROBOPro /home/ROBOPro
     chroot /rom/ su - ROBOPro -c "$DISPLAY ./TxtControlMain /dev/ttyO2 65000"
 done

--- a/board/fischertechnik/TXT/user.tab
+++ b/board/fischertechnik/TXT/user.tab
@@ -1,3 +1,3 @@
 - -1 i2c 84 - - - -
-ROBOPro 1000 ROBOPro 1000 !=ROBOPro /opt/fischertechnik /bin/sh users,tty,video,audio,i2c
+ROBOPro 1004 ROBOPro 1008 !=ROBOPro /opt/fischertechnik /bin/sh users,tty,video,audio,i2c
 ftc 1001 ftc 1001 - /home/ftc /bin/sh users,tty,video,audio,i2c,sudo,gpio,dialout


### PR DESCRIPTION
Fix permission and mounting issues that prevent saving and loading robopro files
```
# chroot /rom/ /bin/su - ROBOPro -c "./TxtControlMain /dev/ttyO2 65000"
...
Error writing flash file /opt/knobloch/ROBOPro/test.bin (Permission denied)
...
```

Closes #284 