### PR TITLE
Float vs int fixes in TouchAuxCamWidget

### DIFF
--- a/board/fischertechnik/TXT/rootfs/opt/ftc/TouchAuxiliary.py
+++ b/board/fischertechnik/TXT/rootfs/opt/ftc/TouchAuxiliary.py
@@ -252,7 +252,7 @@ class TouchAuxCamWidget(QWidget):
         self.cwidth=cwidth
         
         self.pwidth=cwidth
-        self.pheight=cwidth*3/4
+        self.pheight=(cwidth*3)//4
         
         CAM_DEV = os.environ.get('FTC_CAM')
         if CAM_DEV == None:
@@ -264,7 +264,7 @@ class TouchAuxCamWidget(QWidget):
         self.cap = cv2.VideoCapture(CAM_DEV)
         if self.cap.isOpened():
             self.cap.set(3,cwidth)
-            self.cap.set(4,cwidth*3/4)
+            self.cap.set(4,(cwidth*3)//4)
             self.cap.set(5,fps)
         
         self.timer = QTimer(self)
@@ -280,7 +280,7 @@ class TouchAuxCamWidget(QWidget):
 
     def sizeHint(self):
         try:
-            return QSize(self.cwidth,self.cwidth*3/4)
+            return QSize(self.cwidth,(self.cwidth*3)//4)
         except:
             return QSize(320,240)
 

--- a/board/fischertechnik/TXT/rootfs/opt/ftc/TouchAuxiliary.py
+++ b/board/fischertechnik/TXT/rootfs/opt/ftc/TouchAuxiliary.py
@@ -269,7 +269,7 @@ class TouchAuxCamWidget(QWidget):
         
         self.timer = QTimer(self)
         self.timer.timeout.connect(self.update)
-        self.timer.start(1000/fps)
+        self.timer.start(1000//fps)
 
         qsp = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
         qsp.setHeightForWidth(True)
@@ -285,7 +285,7 @@ class TouchAuxCamWidget(QWidget):
             return QSize(320,240)
 
     def heightForWidth(self,w):
-        return w*3/4
+        return (w*3)//4
     
     def closeCam(self):
         self.cap.release()    
@@ -296,7 +296,7 @@ class TouchAuxCamWidget(QWidget):
         # expand/shrink to widget size
         if self.zoom:
             wsize = (self.size().width()*2, self.size().height()*2)
-            rect=QRect(self.size().width()/2,self.size().height()/2,self.size().width(), self.size().height())
+            rect=QRect(self.size().width()//2,self.size().height()//2,self.size().width(), self.size().height())
         else:
             wsize = (self.size().width(), self.size().height())
             rect=QRect(0,0,self.size().width(), self.size().height())


### PR DESCRIPTION
Dear all, please find attached two commits which replace float divisions by int divisions to make sure that PyQt5 does not complain about float objects where it expects objects. 
The first commit are the ones that I had to implement to get the TXTshow app to run without terminating the moment you selected the camera icon. The second commit are covering the remaining float divisions that did not trigger during tests of TXTshow and some other apps from the ftc app store.

Regression testing performed: I tested these fixes by running the apps TXTshow, IOlyser, StartIDE and Benoit with this version of TouchAuxiliary.py copied into the local app directory, so that this version would be imported when needed rather than the preinstalled one in /opt/ftc. 