### PR TITLE
Python/OpenCV fix for those apps which use TouchAuxFTCamPhotoRequester()

### DIFF
--- a/board/fischertechnik/TXT/rootfs/opt/ftc/TouchAuxiliary.py
+++ b/board/fischertechnik/TXT/rootfs/opt/ftc/TouchAuxiliary.py
@@ -266,6 +266,8 @@ class TouchAuxCamWidget(QWidget):
             self.cap.set(3,cwidth)
             self.cap.set(4,cwidth*3/4)
             self.cap.set(5,fps)
+            # fix from https://raspberrypi.stackexchange.com/questions/105358/raspberry-pi4-error-while-using-2-usb-cameras-vidioc-qbuf-invalid-argument
+            self.cap.set(cv2.CAP_PROP_FOURCC,cv2.VideoWriter_fourcc('M','J','P','G'))
         
         self.timer = QTimer(self)
         self.timer.timeout.connect(self.update)


### PR DESCRIPTION
Dear all,

When trying to use the photo shooting functionality offered by TXTshow, it failed with  the 'select()' system call timing out, and no picture was grabbed. 

I understand that other python programs which are using the FT camera are performing this fix themselves, as they import openCV themselves and perform the openCV camera initialization as part of their code. 

TXTshow is different in that respect, as it uses the abstraction methods for the camera introduced by TouchAuxiliary.py such as TouchAuxFTCamPhotoRequester(). So to my understanding, this fix is should go here inside the camera handling method of TouchAuxiliary.py as the cv2 camera object is not 'accessible' in the  python code of the TXTshow app itself.

Best regards,

Knut